### PR TITLE
add note about debugging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ From this point out, it's basic django development. You'll probably
 want to do a `./manage.py startapp` to create your own application
 within the project and so on.
 
+
+#### Debugging Tests ####
+
+Nose captures the output of the tests and redirects it. When you insert a
+breakpoint with `import pdb; pdb.set_trace()`, the pdb shell won't be visible
+on your command line. Instead, use
+`from nose.tools import set_trace; set_trace()` when debugging tests in
+ccnmtldjango.
+
+When debugging tests, sometimes it's useful to run only the test you're
+working on. To do this, you can specify the test class and method along with
+the file like this:
+
+    ./manage.py test ./dmt/api/tests/test_views.py:NotifyTests.test_get
+
 --------------------------
 Setting up a fresh checkout
 


### PR DESCRIPTION
You have to run the tests in a certain way if you want to use `pdb` with ccnmtldjango, so I added a note about it in the readme.
