### PR TITLE
Add -f option to Makefile rm commands

### DIFF
--- a/ccnmtldjango/template/Makefile_tmpl
+++ b/ccnmtldjango/template/Makefile_tmpl
@@ -30,8 +30,7 @@ clean:
 	rm -rf ve
 	rm -rf media/CACHE
 	rm -rf reports
-	rm celerybeat-schedule
-	rm .coverage
+	rm -f celerybeat-schedule .coverage
 	find . -name '*.pyc' -exec rm {} \;
 
 pull:


### PR DESCRIPTION
So it doesn't throw an error when these files don't exist
