### PR TITLE
Use ipython 1.2.1

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -20,7 +20,7 @@ cssselect==0.9.1
 lxml==3.4.0
 fuzzywuzzy==0.4.0
 sure==1.2.7
-ipython==0.13.2
+ipython==1.2.1
 ipdb==0.8
 rdflib==4.1.2
 selenium==2.44.0


### PR DESCRIPTION
ipython 1.x doesn't have the GNU Readline requirement which causes
problems on OS X.
