### PR TITLE
Ignore migrations when checking flake8

### DIFF
--- a/ccnmtldjango/template/Makefile_tmpl
+++ b/ccnmtldjango/template/Makefile_tmpl
@@ -12,7 +12,7 @@ test: ./ve/bin/python
 	$$(MANAGE) jenkins
 
 flake8: ./ve/bin/python
-	$$(FLAKE8) $$(APP) --max-complexity=10
+	$$(FLAKE8) $$(APP) --exclude=migrations --max-complexity=10
 
 runserver: ./ve/bin/python validate
 	$$(MANAGE) runserver


### PR DESCRIPTION
So we don't have to add a flake8 ignore line to each migration
