### PR TITLE
knock lxml back to 3.2.3

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -17,7 +17,7 @@ flake8==2.2.5
 tornado==3.1.1
 BeautifulSoup==3.2.1
 cssselect==0.9.1
-lxml==3.4.0
+lxml==3.2.3
 fuzzywuzzy==0.4.0
 sure==1.2.7
 ipython==1.2.1


### PR DESCRIPTION
3.4.0 has some compilation issues. see https://github.com/ccnmtl/dmt/commit/d2c247b86375f2761b9ae2f544ee9a113b40378e
