### PR TITLE
Add CsrfViewMiddleware to MIDDLEWARE_CLASSES

### DIFF
--- a/ccnmtldjango/template/+package+/settings_shared.py_tmpl
+++ b/ccnmtldjango/template/+package+/settings_shared.py_tmpl
@@ -76,6 +76,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
This middleware is enabled by default in Django, but since we are
overriding MIDDLEWARE_CLASSES, we need to add it here.
https://docs.djangoproject.com/en/dev/ref/csrf/#how-to-use-it
