### PR TITLE
As of django 1.7, admin.autodiscover() is called automatically

### DIFF
--- a/ccnmtldjango/template/+package+/urls.py_tmpl
+++ b/ccnmtldjango/template/+package+/urls.py_tmpl
@@ -6,7 +6,6 @@ from django.views.generic import TemplateView
 from pagetree.generic.views import PageView, EditView, InstructorView
 from ${package}.main import views
 import os.path
-admin.autodiscover()
 
 site_media_root = os.path.join(os.path.dirname(__file__), "../media")
 


### PR DESCRIPTION
...when django.contrib.admin is in INSTALLED_APPS
https://docs.djangoproject.com/en/1.7//ref/contrib/admin/#django.contrib.admin.autodiscover
