### PR TITLE
Fix styles on our custom admin login template

### DIFF
--- a/ccnmtldjango/template/+package+/templates/admin/login.html
+++ b/ccnmtldjango/template/+package+/templates/admin/login.html
@@ -1,38 +1,55 @@
-
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n admin_static %}
 
-{% block stylesheet %}{{STATIC_URL}}admin/css/login.css{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />{% endblock %}
 
-{% block bodyclass %}login{% endblock %}
+{% block bodyclass %}{{ block.super }} login{% endblock %}
 
 {% block content_title %}{% endblock %}
 
 {% block breadcrumbs %}{% endblock %}
 
 {% block content %}
-{% if error_message %}
-<p class="errornote">{{ error_message }}</p>
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% if form.errors.items|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+</p>
 {% endif %}
-<div id="content-main">
-<form method="get" action="{{ CAS_BASE }}cas/login">
-<input type="hidden" name="destination" value="https://{{ request.get_host }}/accounts/caslogin/?next=/admin/&this_is_the_login_form=1" />
-<p>If you have a Columbia UNI, you already have an account and can
-login through CAS with it</p>
-<input type="submit" value="Here" />
-</form>
-<p>otherwise: </p>
 
-<form action="{{ app_path }}" method="post" id="login-form">
-    {% csrf_token %}
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+    <form method="get" action="{{ CAS_BASE }}cas/login">
+        <input type="hidden" name="destination"
+               value="https://{{ request.get_host }}/accounts/caslogin/?next=/admin/&this_is_the_login_form=1" />
+        <p>If you have a Columbia UNI, you already have an account and can
+            login through CAS with it <input type="submit" value="Here" /></p>
+    </form>
+
+    <p>otherwise:</p>
+
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
   <div class="form-row">
-    <label for="id_username">{% trans 'Username:' %}</label> <input type="text" name="username" id="id_username" />
+    {{ form.username.errors }}
+    <label for="id_username" class="required">{{ form.username.label }}:</label> {{ form.username }}
   </div>
   <div class="form-row">
-    <label for="id_password">{% trans 'Password:' %}</label> <input type="password" name="password" id="id_password" />
-    <input type="hidden" name="this_is_the_login_form" value="1" />
-    <input type="hidden" name="post_data" value="{{ post_data }}" /> {#<span class="help">{% trans 'Have you <a href="/password_reset/">forgotten your password</a>?' %}</span>#}
+    {{ form.password.errors }}
+    <label for="id_password" class="required">{% trans 'Password:' %}</label> {{ form.password }}
+    <input type="hidden" name="next" value="{{ next }}" />
   </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% trans 'Forgotten your password or username?' %}</a>
+  </div>
+  {% endif %}
   <div class="submit-row">
     <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
   </div>
@@ -43,5 +60,3 @@ document.getElementById('id_username').focus()
 </script>
 </div>
 {% endblock %}
-
-


### PR DESCRIPTION
The main problem here was that our admin template wasn't including `/media/admin/css/base.css`, which is included on Django's login template by calling `block.super`. I've just copied all the relevant parts of Django 1.7.5's `login.html` template onto our custom template.

![2015-02-27-154110_520x433_scrot](https://cloud.githubusercontent.com/assets/59292/6420852/ec9545f6-be97-11e4-80d3-31fa2b77c8ac.png)

Now looks correct:

![2015-02-27-154055_477x392_scrot](https://cloud.githubusercontent.com/assets/59292/6420853/ef31122c-be97-11e4-80bc-646e630f2e75.png)