### PR TITLE
Switch from nose test runner to django's test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ What it provides for us that startproject doesn't:
   (https://github.com/dcramer/raven/) and configured for our sentry
   setup
 * raven configured to not run on south migrations
-* `South` is included for database migrations
 * `django-annoying` is included (I like `@render_to`)
-* `django-nose` installed and set up as test runner (much nicer!)
-* coverage reports configured for `django-nose`
 * sqlite in-memory database used for unit tests
 * south tests automatically skipped on `./manage.py test` (they break)
 * `django_compressor` added and set up to compress css on production
@@ -205,9 +202,9 @@ within the project and so on.
 
 When debugging tests, sometimes it's useful to run only the test you're
 working on. To do this, you can specify the test class and method along with
-the file like this:
+the module like this:
 
-    ./manage.py test ./dmt/api/tests/test_views.py:NotifyTests.test_get
+    ./manage.py test dmt.api.tests.test_views.NotifyTests.test_get
 
 --------------------------
 Setting up a fresh checkout

--- a/ccnmtldjango/template/+package+/settings_shared.py_tmpl
+++ b/ccnmtldjango/template/+package+/settings_shared.py_tmpl
@@ -32,12 +32,7 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
         }
     }
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-package=${package}',
-]
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 JENKINS_TASKS = (
     'django_jenkins.tasks.run_pylint',
@@ -112,7 +107,6 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'tagging',
     'typogrify',
-    'django_nose',
     'compressor',
     'django_statsd',
     'bootstrap3',

--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -6,7 +6,6 @@ smartypants==1.8.6
 uuid==1.30
 psycopg2==2.6
 Pillow==2.8.1
-nose==1.3.6
 versiontools==1.9.1
 statsd==3.1
 pep8==1.5.7
@@ -44,7 +43,6 @@ django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-paging==0.2.5
 django-annoying==0.8.1
-django-nose==1.3
 django-appconf==1.0.1
 django_compressor==1.4
 django-statsd-mozilla==0.3.14


### PR DESCRIPTION
Django's test runner seems to have improved, and we no longer
need nose. Getting rid of nose simplifies things and makes Django
upgrades easier.

I haven't yet set up the automated coverage tool for the Django
test runner. I'm sure it must be possible, but I don't use that
feature regularly, so I haven't done it yet.