### PR TITLE
Install pytz by default

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.7.7
+pytz==2015.4
 httplib2==0.9
 feedparser==5.1.3
 Markdown==2.6.1


### PR DESCRIPTION
Django recommends that pytz is installed when using USE_TZ=True:
https://docs.djangoproject.com/en/1.8/topics/i18n/timezones/#faq