### PR TITLE
Update debug toolbar panel locations

### DIFF
--- a/ccnmtldjango/template/+package+/settings_shared.py_tmpl
+++ b/ccnmtldjango/template/+package+/settings_shared.py_tmpl
@@ -148,13 +148,13 @@ PAGEBLOCKS = ['pageblocks.TextBlock',
 
 INTERNAL_IPS = ('127.0.0.1', )
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.template.TemplateDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
 )
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 


### PR DESCRIPTION
Changing these to what is documented here:
http://django-debug-toolbar.readthedocs.org/en/1.3/configuration.html#debug-toolbar-panels