### PR TITLE
Remove uuid

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -3,7 +3,6 @@ pytz==2016.7
 httplib2==0.9.2
 feedparser==5.2.1
 Markdown==2.6.7
-uuid==1.30
 psycopg2==2.6.2
 Pillow==3.4.2
 versiontools==1.9.1


### PR DESCRIPTION
No longer necessary as of python 2.5.