### PR TITLE
Include django-cacheds3storage

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -86,6 +86,7 @@ gunicorn==19.7.1
 django-infranil==1.1.0
 django-flatblocks==0.9.4
 django-storages-redux==1.3.3
+django-cacheds3storage==0.1.2
 
 wagtail==1.12.2
 djangorestframework==3.7.1


### PR DESCRIPTION
This is required by staging.py in ccnmtlsettings.