### PR TITLE
Add cryptography package for pyOpenSSL

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -40,6 +40,7 @@ rdflib==4.2.2
 selenium==3.6.0
 coverage==4.4.1
 pyasn1==0.3.7
+cryptography==2.1.1  # for PyOpenSSL
 pyOpenSSL==17.3.0
 ndg-httpsclient==0.4.3
 urllib3==1.22  # requests


### PR DESCRIPTION
This is a dependency of pyOpenSSL. On econplayground, I have to install
this package with `--no-binary` to force it to build on the system to
prevent some linking errors. I haven't introduced that change here, but
I may add it later if it proves to always be necessary.