### PR TITLE
Remove "load url from future"

### DIFF
--- a/ccnmtldjango/template/+package+/templates/impersonate/list_users.html
+++ b/ccnmtldjango/template/+package+/templates/impersonate/list_users.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load url from future %}
 {% block pagetitle %}<h1>Django Impersonate User List</h1>{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This causes a TemplateSyntaxError in python 3:

> 'future' is not a registered tag library.

The `url` templatetag has been included by default by django for a while now, so this can be removed.