### PR TITLE
Use pyyaml 3.12

### DIFF
--- a/ccnmtldjango/template/requirements.txt
+++ b/ccnmtldjango/template/requirements.txt
@@ -107,6 +107,6 @@ webencodings==0.5.1 # needed for wagtail
 ccnmtlsettings==1.4.0
 
 pbr==4.0.4  # bandit
-PyYAML==4.1  # bandit
+PyYAML==3.12  # bandit
 stevedore==1.28.0  # bandit
 bandit==1.4.0


### PR DESCRIPTION
version 4.1 is causing errors because it's not on pypi: https://travis-ci.org/ccnmtl/ccnmtldjango/jobs/398362247